### PR TITLE
detect if a cell's garden process has stalled

### DIFF
--- a/src/nimbus_alerts/cloudfoundry_alerts/cf_diego.alerts.yml
+++ b/src/nimbus_alerts/cloudfoundry_alerts/cf_diego.alerts.yml
@@ -132,3 +132,16 @@ groups:
         had a desired LRP sync duration of {{$value}} seconds during the last 15m
       summary: 'Diego Nsync bulker desired LRP sync duration at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}`
         is too high: {{$value}} sec'
+  - alert: CFDiegoGardenProcessStalled
+    expr: changes(bosh_job_process_cpu_total{bosh_job_process_name="garden"}[30m]) == 0
+      > 0
+    for: 15m
+    labels:
+      monitored_item: '{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}'
+      service: cf
+      severity: warning
+      spark: "false"
+    annotations:
+      description: Diego garden process stalled at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}`
+      summary: 'Diego garden process stalled at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}.`
+        The cell may to unresponsive'


### PR DESCRIPTION
Add monitoring to alert when a Diego cell's garden process has no changes for more then 30 minutes. This can be a sign of an unresponsive cell